### PR TITLE
ci: Added pre-commit hook to check configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
     hooks:
       - id: flake8
         args: [--config, .flake8]
+        
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0 # Use the ref you want to point at
+    hooks:
+      - id: check-yaml
+        name: check yaml
+        description: checks yaml files for parseable syntax.
+        entry: check-yaml
+        language: python
+        types: [yaml]


### PR DESCRIPTION
- [ ] I have battle-tested on Overtaci (RMAPPS1279) - Not relevant
- [ ] I have bumped the version as described in the wiki - Not relevant

## Notes for reviewers
Added pre-commit hook to check configs. Notably for checking that we don't have invalid training configs.