### PR TITLE
fix: change basic bar plot to matplotlib. Closes Plot bar chart in matplotlib #217

### DIFF
--- a/src/psycopt2d/visualization/base_charts.py
+++ b/src/psycopt2d/visualization/base_charts.py
@@ -1,56 +1,68 @@
-from typing import Iterable, Optional
+from pathlib import Path
+from typing import Iterable, Optional, Union
 
-import altair as alt
+import matplotlib.pyplot as plt
 import pandas as pd
 
 
-def plot_bar_chart(
+def plot_basic_chart(
     x_values: Iterable,
     y_values: Iterable,
     x_title: str,
     y_title: str,
+    plot_type: Optional[Union[list[str], str]],
     sort_x: Optional[Iterable[int]] = None,
     sort_y: Optional[Iterable[int]] = None,
-) -> alt.Chart:
-    """Plot a basic bar chart with Altair.
+    fig_size: Optional[tuple] = (10, 10),
+    save_path: Optional[Path] = None,
+) -> Union[None, Path]:
+    """Plot a simple chart using matplotlib. Options for sorting the x and y
+    axis are available.
 
     Args:
         x_values (Iterable): The x values of the bar chart.
         y_values (Iterable): The y values of the bar chart.
         x_title (str): title of x axis
         y_title (str): title of y axis
+        plot_type (Optional[Union[List[str], str]], optional): type of plots.
+            Options are combinations of ["bar", "hbar", "line", "scatter"] Defaults to "bar".
         sort_x (Optional[Iterable[int]], optional): order of values on the x-axis. Defaults to None.
         sort_y (Optional[Iterable[int]], optional): order of values on the y-axis. Defaults to None.
+        fig_size (Optional[tuple], optional): figure size. Defaults to None.
+        save_path (Optional[Path], optional): path to save figure. Defaults to None.
 
     Returns:
-        alt.Chart: Altair chart
+        Union[None, Path]: None if save_path is None, else path to saved figure
     """
+    if isinstance(plot_type, str):
+        plot_type = [plot_type]
 
-    df = pd.DataFrame({"x": x_values, "y": y_values, "sort": sort_x})
+    df = pd.DataFrame(
+        {"x": x_values, "y": y_values, "sort_x": sort_x, "sort_y": sort_y},
+    )
 
     if sort_x is not None:
-        x_axis = alt.X(
-            "x",
-            axis=alt.Axis(title=x_title),
-            sort=alt.SortField(field="sort"),
-        )
-    else:
-        x_axis = alt.X("x", axis=alt.Axis(title=x_title))
+        df = df.sort_values(by=["sort_x"])
 
     if sort_y is not None:
-        y_axis = alt.Y(
-            "y",
-            axis=alt.Axis(title=y_title),
-            sort=alt.SortField(field="sort"),
-        )
-    else:
-        y_axis = alt.Y("y", axis=alt.Axis(title=y_title))
+        df = df.sort_values(by=["sort_y"])
 
-    return (
-        alt.Chart(df)
-        .mark_bar()
-        .encode(
-            x=x_axis,
-            y=y_axis,
-        )
-    )
+    plt.figure(figsize=fig_size)
+
+    plt.figure(figsize=fig_size)
+    if "bar" in plot_type:
+        plt.bar(df["x"], df["y"])
+    if "hbar" in plot_type:
+        plt.barh(df["x"], df["y"])
+    if "line" in plot_type:
+        plt.plot(df["x"], df["y"])
+    if "scatter" in plot_type:
+        plt.scatter(df["x"], df["y"])
+
+    plt.xlabel(x_title)
+    plt.ylabel(y_title)
+
+    if save_path is not None:
+        plt.savefig(save_path)
+    plt.close()
+    return save_path

--- a/src/psycopt2d/visualization/feature_importance.py
+++ b/src/psycopt2d/visualization/feature_importance.py
@@ -1,15 +1,17 @@
-from typing import Iterable, List, Union
+from pathlib import Path
+from typing import Iterable, Optional, Union
 
 import altair as alt
 import numpy as np
 
-from psycopt2d.visualization.base_charts import plot_bar_chart
+from psycopt2d.visualization.base_charts import plot_basic_chart
 
 
 def plot_feature_importances(
     column_names: Iterable[str],
-    feature_importances: Union[List[float], np.ndarray],
+    feature_importances: Union[list[float], np.ndarray],
     top_n_feature_importances: int,
+    save_path: Optional[Path] = None,
 ) -> alt.Chart:
     """Plots feature importances.
 
@@ -23,6 +25,7 @@ def plot_feature_importances(
         column_names (Iterable[str]): Column/feature names
         feature_importances (Iterable[str]): Feature importances
         top_n_feature_importances (int): Top n features to plot
+        save_path (Optional[Path], optional): Path to save the plot. Defaults to None.
 
     Returns:
         alt.Chart: Horizontal barchart of feature importances
@@ -35,10 +38,12 @@ def plot_feature_importances(
     feature_names = np.array(column_names)[sorted_idx][:top_n_feature_importances]
     feature_importances = feature_importances[sorted_idx][:top_n_feature_importances]
 
-    return plot_bar_chart(
-        x_values=feature_importances,
-        y_values=feature_names,
+    return plot_basic_chart(
+        x_values=feature_names,
+        y_values=feature_importances,
         x_title="Feature importance (gain)",
         y_title="Feature name",
-        sort_y=np.arange(len(feature_importances)),
+        sort_x=np.arange(len(feature_importances)),
+        plot_type="hbar",
+        save_path=save_path,
     )

--- a/src/psycopt2d/visualization/performance_over_time.py
+++ b/src/psycopt2d/visualization/performance_over_time.py
@@ -3,6 +3,7 @@
 2. AUC by time from first visit
 3. AUC by time until diagnosis
 """
+from pathlib import Path
 from typing import Callable, Iterable, List, Optional
 
 import altair as alt
@@ -12,7 +13,7 @@ from sklearn.metrics import f1_score, roc_auc_score
 from wasabi import msg
 
 from psycopt2d.utils import bin_continuous_data, round_floats_to_edge
-from psycopt2d.visualization.base_charts import plot_bar_chart
+from psycopt2d.visualization.base_charts import plot_basic_chart
 
 
 def _calc_performance(df: pd.DataFrame, metric: Callable) -> float:
@@ -67,6 +68,7 @@ def plot_performance_by_calendar_time(
     metric_fn: Callable,
     bin_period: str,
     y_title: str,
+    save_path: Optional[str] = None,
 ) -> alt.Chart:
     """Plot performance by calendar time of prediciton.
 
@@ -77,6 +79,7 @@ def plot_performance_by_calendar_time(
         metric_fn (Callable): Function which returns the metric.
         bin_period (str): Which time period to bin on. Takes "M" or "Y".
         y_title (str): Title of y-axis.
+        save_path (str, optional): Path to save figure. Defaults to None.
 
     Returns:
         alt.Chart: Bar chart of performance
@@ -89,12 +92,14 @@ def plot_performance_by_calendar_time(
         bin_period=bin_period,
     )
     sort_order = np.arange(len(df))
-    return plot_bar_chart(
+    return plot_basic_chart(
         x_values=df["time_bin"],
         y_values=df["metric"],
         x_title="Calendar time",
         y_title=y_title,
         sort_x=sort_order,
+        plot_type="line",
+        save_path=save_path,
     )
 
 
@@ -174,6 +179,7 @@ def plot_auc_by_time_from_first_visit(
     prediction_timestamps: Iterable[pd.Timestamp],
     bins=[0, 28, 182, 365, 730, 1825],
     pretty_bins: Optional[bool] = True,
+    save_path: Optional[Path] = None,
 ) -> alt.Chart:
     """Plot AUC as a function of time to first visit.
 
@@ -185,6 +191,7 @@ def plot_auc_by_time_from_first_visit(
         bins (list, optional): Bins to group by. Defaults to [0, 28, 182, 365, 730, 1825].
         pretty_bins (bool, optional): Prettify bin names. I.e. make
         bins look like "1-7" instead of "[1-7)" Defaults to True.
+        save_path (Path, optional): Path to save figure. Defaults to None.
 
     Returns:
         alt.Chart: Altair bar chart
@@ -203,12 +210,14 @@ def plot_auc_by_time_from_first_visit(
     )
 
     sort_order = np.arange(len(df))
-    return plot_bar_chart(
+    return plot_basic_chart(
         x_values=df["days_from_event_binned"],
         y_values=df["metric"],
         x_title="Days from first visit",
         y_title="AUC",
         sort_x=sort_order,
+        plot_type=["line", "scatter"],
+        save_path=save_path,
     )
 
 
@@ -234,6 +243,7 @@ def plot_metric_by_time_until_diagnosis(
     pretty_bins: Optional[bool] = True,
     metric_fn: Callable = f1_score,
     y_title: str = "F1",
+    save_path: Optional[Path] = None,
 ) -> alt.Chart:
     """Plots performance of a specified performance metric in bins of time
     until diagnosis. Rows with no date of diagnosis (i.e. no outcome) are
@@ -249,6 +259,7 @@ def plot_metric_by_time_until_diagnosis(
         pretty_bins (bool, optional): Whether to prettify bin names. Defaults to True.
         metric_fn (Callable): Which performance metric  function to use.
         y_title (str): Title for y-axis (metric name)
+        save_path (Path, optional): Path to save figure. Defaults to None.
 
     Returns:
         alt.Chart: Altair bar chart
@@ -266,10 +277,12 @@ def plot_metric_by_time_until_diagnosis(
     )
     sort_order = np.arange(len(df))
 
-    return plot_bar_chart(
+    return plot_basic_chart(
         x_values=df["days_from_event_binned"],
         y_values=df["metric"],
         x_title="Days to diagnosis",
         y_title=y_title,
         sort_x=sort_order,
+        plot_type=["line", "scatter"],
+        save_path=save_path,
     )

--- a/src/psycopt2d/visualization/utils.py
+++ b/src/psycopt2d/visualization/utils.py
@@ -32,6 +32,17 @@ def altair_chart_to_file(
     return str(filepath)
 
 
+def log_image_to_wandb(chart_path: Path, chart_name: str, run: wandb.run):
+    """Helper to log image to wandb.
+
+    Args:
+        chart_path (Path): Path to the image
+        chart_name (str): Name of the chart
+        run (wandb.run): Wandb run object
+    """
+    run.log({f"image_{chart_name}": wandb.Image(str(chart_path))})
+
+
 def log_altair_to_wandb(chart: Chart, chart_name: str, run: wandb.run):
     """Helper to log Altair charts.
 

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -7,7 +7,7 @@ from sklearn.metrics import f1_score, roc_auc_score
 
 from psycopt2d.utils import positive_rate_to_pred_probs
 from psycopt2d.visualization import plot_prob_over_time
-from psycopt2d.visualization.base_charts import plot_bar_chart
+from psycopt2d.visualization.base_charts import plot_basic_chart
 from psycopt2d.visualization.feature_importance import plot_feature_importances
 from psycopt2d.visualization.performance_over_time import (
     plot_auc_by_time_from_first_visit,
@@ -64,17 +64,16 @@ def test_plot_bar_chart(df):
         prediction_timestamps=df["timestamp"],
         pred_proba_threshold=0.5,
     )
-    plot_bar_chart(
+    plot_basic_chart(
         x_values=plot_df["days_to_outcome_binned"],
         y_values=plot_df["sens"],
         x_title="Days to outcome",
         y_title="Sensitivity",
+        plot_type="bar",
     )
 
 
 def test_plot_performance_by_calendar_time(df):
-    alt.data_transformers.disable_max_rows()
-
     plot_performance_by_calendar_time(
         labels=df["label"],
         y_hat=df["pred"],
@@ -86,8 +85,6 @@ def test_plot_performance_by_calendar_time(df):
 
 
 def test_plot_metric_until_diagnosis(df):
-    alt.data_transformers.disable_max_rows()
-
     plot_metric_by_time_until_diagnosis(
         labels=df["label"],
         y_hat=df["pred"],
@@ -99,8 +96,6 @@ def test_plot_metric_until_diagnosis(df):
 
 
 def test_plot_auc_time_from_first_visit(df):
-    alt.data_transformers.disable_max_rows()
-
     plot_auc_by_time_from_first_visit(
         labels=df["label"],
         y_hat_probs=df["pred_prob"],
@@ -129,7 +124,7 @@ def test_sens_by_time_to_outcome(df):
 
 def test_plot_feature_importances():
     feature_names = ["very long feature name right here yeah", "feat2", "feat3"]
-    feature_importance = [0.6, 0.3, 0.1]
+    feature_importance = [0.6, 0.7, 0.1]
 
     plot_feature_importances(
         feature_names,


### PR DESCRIPTION
- [X] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have bumped the version as described in the [wiki](https://www.notion.so/Setting-up-Poetry-on-your-local-machine-76647d75e8fa4d9ba553cbc2a49946d9#dca1e0f2ce934a49acd1851aaf882d75)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies

## Notes for reviewers
Tests might fail due to not all plots having been remade in matplotlib yet. It's all cool though B-)