### PR TITLE
fix: add auto-release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
 - [ ] I have battle-tested on Overtaci (RMAPPS1279)
-- [ ] I have bumped the version as described in the [wiki](https://www.notion.so/Setting-up-Poetry-on-your-local-machine-76647d75e8fa4d9ba553cbc2a49946d9#dca1e0f2ce934a49acd1851aaf882d75)
 - [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies
 
 ## Notes for reviewers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      uses: relekang/python-semantic-release@v7.32.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Remember to copy the tool.semantic_release section from pyproject.toml 
+        # as well

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,6 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-branch = "main"
-upload_to_pypi = false
-upload_to_release = true
-build_command = "poetry build"
-
 [tool.isort]
 known_third_party = ["wandb"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,4 +77,13 @@ known_third_party = ["wandb"]
 [tool.mypy]
 ignore_missing_imports = true
 
+[tool.semantic_release]
+branch = "main"
+version_variable = [
+    "pyproject.toml:version"
+]
+upload_to_pypi = false
+upload_to_release = true
+build_command = "pip install poetry && poetry build"
+
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,6 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.semantic_release]
-version_variable = [
-    "pyproject.toml:version"
-]
 branch = "main"
 upload_to_pypi = false
 upload_to_release = true


### PR DESCRIPTION
I have battle-tested on Overtaci (RMAPPS1279): N/A
I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies: N/A
